### PR TITLE
Introduce hierarchical order for groups

### DIFF
--- a/server.go
+++ b/server.go
@@ -104,12 +104,12 @@ func (server *Server) searchHandler(w http.ResponseWriter, r *http.Request) {
 
 func (server *Server) flattenEntities(result *[]volkszaehler.Entity, entities []volkszaehler.Entity, parent string) {
 	for _, entity := range entities {
+		if parent != "" {
+			entity.Title = fmt.Sprintf("%s/%s", parent, entity.Title)
+		}			
 		if entity.Type == "group" {
 			server.flattenEntities(result, entity.Children, entity.Title)
 		} else {
-			if parent != "" {
-				entity.Title = fmt.Sprintf("%s (%s)", entity.Title, parent)
-			}
 			*result = append(*result, entity)
 		}
 	}


### PR DESCRIPTION
Until now only the direct parent is shown in braces after the title. In a hierarchical structure with several levels that's not sufficient.
because e.g. in the following structure within Volkszähler

```
my building                                  (type building)
|- 1st floor                                 (type group)
|    |- bathroom                             (type group)
|    |    |- temperature                     (type sensor)
|    |    \- humidity                        (type sensor)
|    \- sleeping room                        (type group)
|         |- temperature                     (type sensor)
|         \- humidity                        (type sensor)
\- 2nd floor                                 (type group)
     \- bathroom                             (type group)
          |- temperature                     (type sensor)
          \- humidity                        (type sensor)
```

The generated entries would be:
```
 humidity (bathroom)
 humidity (bathroom)
 humidity (sleeping room)
 temperature (bathroom)
 temperature (bathroom)
 temperature (sleeping room)
 ```
Therefore this change creates a folder like structure for groups where this entries become to:
```
my building\1st floor\bathroom\humidity
my building\1st floor\bathroom\temperature
my building\1st floor\sleeping room\humidity
my building\1st floor\sleeping room\temperature
my building\2nd floor\bathroom\humidity
my building\2nd floor\bathroom\temperature
```